### PR TITLE
Fix Parallel IP Geolocation and Thread-Safety

### DIFF
--- a/geoip2_mcp_server/server.py
+++ b/geoip2_mcp_server/server.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import ipaddress
+import threading
 import geoip2.database
 import geoip2.errors
 from pydantic import BaseModel, Field, field_validator
@@ -158,6 +159,7 @@ class ServerState:
         self.request_count = 0
         self.start_time = datetime.now()
         self.db_info: Dict[str, Any] = {}
+        self._lock = threading.Lock()
 
         # Lazy readers
         self._city_reader: Optional[geoip2.database.Reader] = None
@@ -209,14 +211,18 @@ class ServerState:
         if not Path(self.city_db_path).exists():
             raise FileNotFoundError(f"City database not found at {self.city_db_path}")
         if self._city_reader is None:
-            self._city_reader = geoip2.database.Reader(self.city_db_path)
+            with self._lock:
+                if self._city_reader is None:
+                    self._city_reader = geoip2.database.Reader(self.city_db_path)
         return self._city_reader
 
     def get_asn_reader(self) -> geoip2.database.Reader:
         if not Path(self.asn_db_path).exists():
             raise FileNotFoundError(f"ASN database not found at {self.asn_db_path}")
         if self._asn_reader is None:
-            self._asn_reader = geoip2.database.Reader(self.asn_db_path)
+            with self._lock:
+                if self._asn_reader is None:
+                    self._asn_reader = geoip2.database.Reader(self.asn_db_path)
         return self._asn_reader
 
     def get_country_reader(self) -> geoip2.database.Reader:
@@ -225,7 +231,9 @@ class ServerState:
                 f"Country database not found at {self.country_db_path}"
             )
         if self._country_reader is None:
-            self._country_reader = geoip2.database.Reader(self.country_db_path)
+            with self._lock:
+                if self._country_reader is None:
+                    self._country_reader = geoip2.database.Reader(self.country_db_path)
         return self._country_reader
 
 
@@ -581,7 +589,7 @@ def geolocate_ip(
     "geolocate_multiple_ips",
     description="Get geolocation information for multiple IP addresses with batch concurrency",
 )
-def geolocate_multiple_ips(
+async def geolocate_multiple_ips(
     ip_addresses: List[str],
     include_asn: bool = True,
     output_format: Literal["json", "summary", "csv"] = "json",
@@ -633,9 +641,8 @@ def geolocate_multiple_ips(
                 STATE.cache.set(cache_key, item)
             return item
 
-    loop = asyncio.get_event_loop()
-    results: List[Dict[str, Any]] = loop.run_until_complete(
-        asyncio.gather(*(process_ip(ip) for ip in ip_addresses))
+    results: List[Dict[str, Any]] = await asyncio.gather(
+        *(process_ip(ip) for ip in ip_addresses)
     )
 
     return format_output(results, output_format)


### PR DESCRIPTION
### Description
The `geolocate_multiple_ips` tool was previously implemented as a synchronous function that manually tried to manage the event loop. This approach is problematic within `FastMCP` and often leads to hanging or errors when called from a client.

This PR converts `geolocate_multiple_ips` to a native `async def` tool, ensuring it integrates correctly with the library's event loop. Additionally, it adds a `threading.Lock` to the `ServerState` class to make the initialization of database readers thread-safe, preventing potential race conditions during concurrent batch lookups.

### Changes:
- **Asynchronous Tool:** Converted `geolocate_multiple_ips` to `async def` and utilized `await asyncio.gather` for parallel processing.
- **Thread-Safety:** Added a lock to the `ServerState` to ensure only one instance of each GeoIP2 reader is created per database.
- **Concurrency Management:** Correctly utilize the `batch_concurrency` semaphore within the async context.
- **Improved Stability:** Fixed potential event loop-related `RuntimeError` during batch operations.

Verified with syntax check and local execution tests.